### PR TITLE
fix(micro): point open-windoze at the win11 domain

### DIFF
--- a/users/otavio/home/micro.nix
+++ b/users/otavio/home/micro.nix
@@ -43,9 +43,9 @@
       name = "open-windoze";
       runtimeInputs = with pkgs; [ virt-viewer ];
       text = ''
-        virsh -c qemu:///system list --all --state-running --name | grep -q "Windoze" \
-          || virsh -c qemu:///system start Windoze \
-          && exec virt-viewer -f -c qemu:///system Windoze
+        virsh -c qemu:///system list --all --state-running --name | grep -q "win11" \
+          || virsh -c qemu:///system start win11 \
+          && exec virt-viewer -f -c qemu:///system win11
       '';
     })
 


### PR DESCRIPTION
The `open-windoze` script still targeted the `Windoze` libvirt domain, which has been superseded by
a new `win11` guest. Running it started and attached to the retired machine.

Confirmed the exact domain name against `virsh -c qemu:///system list --all` — it is lowercase
`win11`, not `Win11`.